### PR TITLE
修复 result insanceof Promise 在使用 Polifill 时返回 false 的问题

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -102,7 +102,7 @@ var InfiniteScroll = function (_React$Component) {
                     loadCompleted: false,
                     startLoad: true
                 });
-                if (result instanceof Promise) {
+                if (typeof result.then === 'function') {
                     result.then(function () {
                         _this3.setState({
                             loadCompleted: true
@@ -130,7 +130,7 @@ var InfiniteScroll = function (_React$Component) {
                     loadCompleted: false,
                     errorMsg: ''
                 });
-                if (result instanceof Promise) {
+                if (typeof result.then === 'function') {
                     result.then(function () {
                         _this4.setState({
                             loadCompleted: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mb-react-infinite-scroll",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/InfiniteScroll.js",
   "author": "Heboy",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -2,30 +2,37 @@
 
 ##安装方法
 
-npm install git://github.com/Heboy/react-infinite-scroll.git
-
-或者fork到你的git路径下再执行:
-
-npm install '你的git路径'
+```shell
+npm i -S mb-react-infinite-scroll
+```
 
 ##用法
 
 ```
-    import InfiniteScroll from 'infinite-scroll';
-    ...
-    <InfiniteScroll onLoad={this.loadMore.bind(this)} hasMore={true} height="100%">
-         {(()=> {
-             return this.state.items.map((item)=> {
-                 return <Item text={item}/>
-             })
-         })()}
-    </InfiniteScroll>
+import InfiniteScroll from 'mb-react-infinite-scroll';
+...
+<InfiniteScroll onLoad={this.loadMore.bind(this)} hasMore={true} height="100%">
+     {(()=> {
+         return this.state.items.map((item)=> {
+             return <Item text={item}/>
+         })
+     })()}
+</InfiniteScroll>
  ```
  
  onLoad:在该组件滚动到底部时调用，获取更多数据，需要返回Promise类型对象
  
- hasMore:在没有数据后设置该属性为true，将不再请求
  
- height:默认100%，用来确保该组件高度小于内容以便出现滚动条
+ height:
  
  请参考example
+ 
+ 
+### API
+
+* `onLoad`  加载数据用的 function, 要求返回 Promise
+* `retry`   失败后点击重试的 function, 要求返回  Promise
+* `hasMore` 是否有更多数据, 在没有数据后设置该属性为true，将不再请求
+* `height`  默认100%，用来确保该组件高度小于内容以便出现滚动条
+* `langNoMore` 没有更多数据的文本内容
+* `langLoading`  加载中的文本内容

--- a/src/InfiniteScroll.jsx
+++ b/src/InfiniteScroll.jsx
@@ -62,7 +62,7 @@ class InfiniteScroll extends React.Component {
                 loadCompleted: false,
                 startLoad: true
             });
-            if (result instanceof Promise) {
+            if (typeof result.then === 'function') {
                 result.then(()=> {
                         this.setState({
                             loadCompleted: true
@@ -88,7 +88,7 @@ class InfiniteScroll extends React.Component {
                 loadCompleted: false,
                 errorMsg: ''
             });
-            if (result instanceof Promise) {
+            if (typeof result.then === 'function') {
                 result.then(()=> {
                         this.setState({
                             loadCompleted: true


### PR DESCRIPTION
在不支持 Promise 的手机上使用 polyfill 时，在执行 `result insanceof Promise` 检查时会返回 false ， 导致后面的代码无法执行
